### PR TITLE
Get Dockerfile to running state

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,28 +5,6 @@ MAINTAINER Kirstie Whitaker <kw401@cam.ac.uk>
 # Switch to root user for installation
 USER root
 
-# Update conda and install relevant dependencies
-RUN conda update conda --yes --quiet
-RUN conda config --add channels conda-forge
-RUN conda install --yes --quiet matplotlib \
-                                mayavi \
-                                networkx \
-                                nibabel \
-                                numpy \
-                                pandas \
-                                scipy \
-                                seaborn \
-                                scikit-learn
-RUN conda update anaconda --yes --quiet
-RUN python -c "from matplotlib import font_manager"
-RUN conda clean -ay
-
-# Install dependencies in pip
-RUN pip install --upgrade --quiet pip && \
-    pip install --upgrade --quiet community \
-                                  pysurfer \
-                --ignore-installed
-
 # Install the MCR dependencies and some things we'll need and download the MCR
 # from Mathworks -silently install it. Code taken from: 
 #   https://github.com/vistalab/docker/blob/master/matlab/runtime/2015b/Dockerfile
@@ -48,5 +26,27 @@ RUN rm -rf mcr-install
 # Configure environment variables for MCR
 ENV LD_LIBRARY_PATH /opt/mcr/v90/runtime/glnxa64:/opt/mcr/v90/bin/glnxa64:/opt/mcr/v90/sys/os/glnxa64
 ENV XAPPLRESDIR /opt/mcr/v90/X11/app-defaults
+
+# Update conda and install relevant dependencies
+RUN conda update conda --yes --quiet
+RUN conda config --add channels conda-forge
+RUN conda install --yes --quiet matplotlib \
+                                mayavi \
+                                networkx \
+                                nibabel \
+                                numpy=1.10 \
+                                pandas=0.19.2 \
+                                scipy \
+                                seaborn \
+                                scikit-learn
+RUN conda update anaconda --yes --quiet
+RUN python -c "from matplotlib import font_manager"
+RUN conda clean -ay
+
+# Install dependencies in pip
+RUN pip install --upgrade --quiet pip && \
+    pip install --upgrade --quiet community \
+                                  pysurfer \
+                --ignore-installed
 
 CMD ["/bin/bash"]

--- a/NSPN_CorticalMyelination_AnalysisWrapper.py
+++ b/NSPN_CorticalMyelination_AnalysisWrapper.py
@@ -44,6 +44,9 @@ paper_dir = os.path.join(study_dir, 'CT_MT_ANALYSES')
 
 matlab_dir = os.path.join('/usr','local','MATLAB','R2012b','bin','matlab')          ##### EDIT HERE FOR YOUR VERSION OF MATLAB!
 
+import matplotlib
+matplotlib.use('Agg')
+
 #==============================================================================
 # LOAD THE ANALYSIS CODE MODULES
 #==============================================================================


### PR DESCRIPTION
* Move less potentially volatile MATLAB installation higher to avoid rerunning on successive builds
* Set Pandas version to 0.19.2, to recover the [DataFrame.sort](https://pandas.pydata.org/pandas-docs/version/0.19.2/generated/pandas.DataFrame.sort.html) method
* Set numpy version to 1.10.4, for compatibility with Pandas
* Add `matplotlib.use('Agg')` to primary script

Can now be run from repository root:

```Shell
docker build -t nspn:latest -f Dockerfile .
docker run --rm -it -v $PWD:/data nspn:latest \
    python /data/NSPN_CorticalMyelination_AnalysisWrapper.py
```